### PR TITLE
update(ansible-doc): Add steps to add a new target in ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ To add a new target to your setup, follow these steps:
 Add the `target-name` and its corresponding `installer` to the `target_name_map`. The `installer` name can be found in the recipes of the [open-install-library](https://github.com/newrelic/open-install-library) repository.
 
 ## Step 2: Configure Host File
-Update the host file with the IP address of the target. Include SSH configuration for the target.
+Update the host file with the IP address of the target host including SSH configuration for the host.
 
 ## Step 3: Create `playbook.yml`
-Use an existing README as a reference to create a new `playbook.yml`. Add the target key to the `targets` attribute. Include any environment variables required by the agent.
+Use the [Playbook Template](https://github.com/Aashirwadjain/ansible-install/blob/update/ansible-doc/README.md#getting-started) as a reference to create a new `playbook.yml`. Add the target key to the `targets` attribute (include any environment variables required by the agent).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Add the `target-name` and its corresponding `installer` to the `target_name_map`
 Update the host file with the IP address of the target host including SSH configuration for the host.
 
 ## Step 3: Create `playbook.yml`
-Use the [Playbook Template](https://github.com/Aashirwadjain/ansible-install/blob/update/ansible-doc/README.md#getting-started) as a reference to create a new `playbook.yml`. Add the target key to the `targets` attribute (include any environment variables required by the agent).
+Use the [Playbook Template](https://github.com/newrelic/ansible-install?tab=readme-ov-file#example-playbook) as a reference to create a new `playbook.yml`. Add the target key to the `targets` attribute (include any environment variables required by the agent).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
 
 - Find your account ID: [Account ID documentation](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/)
 
+# Adding a Target
+To add a new target to your setup, follow these steps:
+
+## Step 1: Update `defaults/main.yml`
+Add the `target-name` and its corresponding `installer` to the `target_name_map`. The `installer` name can be found in the recipes of the [open-install-library](https://github.com/newrelic/open-install-library) repository.
+
+## Step 2: Configure Host File
+Update the host file with the IP address of the target. Include SSH configuration for the target.
+
+## Step 3: Create `playbook.yml`
+Use an existing README as a reference to create a new `playbook.yml`. Add the target key to the `targets` attribute. Include any environment variables required by the agent.
+
 ## Support
 
 New Relic hosts and moderates an online forum where customers can interact with


### PR DESCRIPTION
### Description
- This PR aims to add documentation to add a new target to `ansible-install`.